### PR TITLE
refactor: postgress configs

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,26 +1,24 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
-default: &default
+# PostgreSQL
+development:
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  database: sample_postgres_development
+  pool: 5
+  username: sample_postgres
+  password: admin
 
-development:
-  <<: *default
-  database: storage/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: sample_postgres_test
+  pool: 5
+  username: sample_postgres
+  password: admin
 
 production:
-  <<: *default
-  database: <%= ENV['DATABASE_URL'].gsub("postgres://", "postgresql://") %>
+  adapter: postgresql
+  encoding: unicode
+  database: sample_postgres_production
+  pool: 5
+  username: sample_postgres
+  password: admin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_05_28_013557) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "authors", force: :cascade do |t|
     t.string "description"
     t.integer "age"
@@ -25,7 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_013557) do
     t.integer "pages"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "author_id"
+    t.bigint "author_id"
     t.index ["author_id"], name: "index_books_on_author_id"
   end
 


### PR DESCRIPTION
Ajustada as configurações do banco de dados
navegue até a pasta onde o arquivo pg_hba.conf está localizado. Geralmente, o caminho é /etc/postgresql/<versão>/main/pg_hba.conf.
Você pode usar um editor de texto como o nano ou vim para editar o arquivo. Por exemplo:
bash
nano /etc/postgresql/<versão>/main/pg_hba.conf
Edite a configuração de autenticação:

Dentro do arquivo pg_hba.conf, encontre a linha que corresponde à autenticação do método peer ou ident.
Altere o método de autenticação para md5 ou password. Por exemplo, altere:
sql
local   all             all                                     peer
para:
sql
Copiar código
local   all             all                                     md5
Isso garantirá que a autenticação seja feita usando uma senha.

depois dessas alterações foi necessário dar um restart no banco de dados 
sudo service postgresql restart

depois criar o banco de dados 
bin/rails db:create